### PR TITLE
flask-login 0.6.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/werkzeug-feedstock/pr10/32826d1
+  - https://staging.continuum.io/prefect/fs/itsdangerous-feedstock/pr4/6569ec4
+  - https://staging.continuum.io/prefect/fs/flask-feedstock/pr11/fc6007f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/werkzeug-feedstock/pr10/32826d1
-  - https://staging.continuum.io/prefect/fs/itsdangerous-feedstock/pr4/6569ec4
-  - https://staging.continuum.io/prefect/fs/flask-feedstock/pr11/fc6007f

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,29 +1,25 @@
 {% set name = "Flask-Login" %}
-{% set version = "0.6.2" %}
-{% set bundle = "tar.gz" %}
+{% set version = "0.6.3" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.{{ bundle }}
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
-  sha256: c0a7baa9fdc448cdd3dd6f0939df72eec5177b2f7abe6cb82fc934d29caac9c3
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5e23d14a607ef12806c699590b89d0f0e0d67baeec599d75947bf9c147330333
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   skip: true  # [py<37]
 
 requirements:
   host:
     - python
     - pip
-    - flask
     - wheel
     - setuptools
-
   run:
     - python
     - flask >=1.0.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,13 +38,11 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  license_url: https://github.com/maxcountryman/flask-login/blob/main/LICENSE
   summary: User session management for Flask
   description: |
     flask-login handles the common tasks  of logging in, logging out, and remembering your users'
     sessions over extended periods of time.
-  doc_url: https://flask-login.readthedocs.io/en/latest/
-  doc_source_url: https://github.com/maxcountryman/flask-login/blob/main/docs/index.rst
+  doc_url: https://flask-login.readthedocs.io/
   dev_url: https://github.com/maxcountryman/flask-login
 
 extra:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4835](https://anaconda.atlassian.net/browse/PKG-4835)
- release-diff: https://github.com/maxcountryman/flask-login/compare/0.6.2...0.6.3
- changelog: https://github.com/maxcountryman/flask-login/blob/main/CHANGES.md
- license: https://github.com/maxcountryman/flask-login/blob/main/LICENSE
- requirements-tagged:
  - https://github.com/maxcountryman/flask-login/tree/0.6.3/requirements
  - https://github.com/maxcountryman/flask-login/blob/0.6.3/setup.cfg
  - https://github.com/maxcountryman/flask-login/blob/0.6.3/setup.py


### Explanation of changes:

- Clean up the recipe by conda-lint
- Remove a redundant `flask` from `host`

### Notes:

- Updating to make it compatible with `flask 3.0.3` https://github.com/AnacondaRecipes/flask-feedstock/pull/11

[PKG-4835]: https://anaconda.atlassian.net/browse/PKG-4835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ